### PR TITLE
Add Dockerfile with an image for C/C++ build environment

### DIFF
--- a/contrib/cmake/Dockerfile
+++ b/contrib/cmake/Dockerfile
@@ -1,0 +1,3 @@
+FROM cirrusci/windowsservercore:2019
+
+RUN choco install -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System' visualstudio2017community visualstudio2017-workload-vctools mingw cmake 


### PR DESCRIPTION
Contains required tools to build C and C++ applications using
Microsoft Visual C++ Compiler or MinGW GCC with or without cmake.

This environment is suitable for (open source) C/C+ projects that support building native Windows applications with cmake.