### PR TITLE
Add Unix tools to path; Add C++ build tools; Drop msys2

### DIFF
--- a/contrib/cmake/Dockerfile
+++ b/contrib/cmake/Dockerfile
@@ -1,10 +1,14 @@
 FROM cirrusci/windowsservercore:2019
 
+# Microsoft .NET Framework 4.8 4.8.0.20190930 is broken and causes the
+# installation of visualstudio2019-workload-vctools to fail. To workaround
+# the issue request Microsoft .NET Framework 4.7.2.20180712 instead, which
+# is already installed and thus speeds up installation as well.
 RUN powershell -NoLogo -NoProfile -Command \
-    choco install -y --no-progress dotnetfx || echo "ignore reboot request"
+    choco install -y --no-progress dotnetfx --version 4.7.2.20180712
 
 RUN powershell -NoLogo -NoProfile -Command \
-    choco install -y --no-progress visualstudio2019community visualstudio2019buildtools
+    choco install -y --no-progress visualstudio2019buildtools visualstudio2019-workload-vctools
 
 RUN powershell -NoLogo -NoProfile -Command \
     choco install -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System' mingw cmake msys2 || echo "ignore reboot request"

--- a/contrib/cmake/Dockerfile
+++ b/contrib/cmake/Dockerfile
@@ -11,4 +11,4 @@ RUN powershell -NoLogo -NoProfile -Command \
     choco install -y --no-progress visualstudio2019buildtools visualstudio2019-workload-vctools
 
 RUN powershell -NoLogo -NoProfile -Command \
-    choco install -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System' mingw cmake msys2 || echo "ignore reboot request"
+    choco install -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System' mingw cmake

--- a/windowsservercore/Dockerfile
+++ b/windowsservercore/Dockerfile
@@ -5,6 +5,7 @@ RUN powershell -NoLogo -NoProfile -Command \
     netsh interface ipv4 set subinterface 18 mtu=1460 store=persistent ; \
     netsh interface ipv4 show interfaces ; \
     Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) ; \
-    choco install -y --no-progress git 7zip ; \
+    choco install -y --no-progress git --params "/GitAndUnixToolsOnPath" ; \
+    choco install -y --no-progress 7zip ; \
     Remove-Item C:\ProgramData\chocolatey\logs -Force -Recurse ; \
     Remove-Item C:\Users\ContainerAdministrator\AppData\Local\Temp -Force -Recurse


### PR DESCRIPTION
This PR:
1. Adds the Unix tools to the path on installation to enable use of `CIRRUS_SHEL: bash` so that the same shell environment can be used across platforms;
2. Adds `visualstudio2019-workload-vctools` to allow users to compile with MSVC;
3. Drops `msys2` to avoid indefinite hangs of Docker.

* Trick to reenable `visualstudio2019-workload-vctools` is to depend on an older version of `dotnetfx`. The latest version has known problems and causes the Visual Studio installer to fail.
* Reasoning behind dropping `msys2` is that it isn't required since the Unix tools that ship with Git are available already and `mingw` is installed separately.

This should solve #12, #13 and #14. Additionally `diff` becomes available and thus should make #11 obsolete. I did a test build before, but [this one](https://cirrus-ci.com/build/4612545413644288) should report success imminently.