### PR TITLE
Include optional components for visualstudio2019-workload-vctools

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,11 +2,13 @@ environment:
   DOCKER_USER_NAME: ENCRYPTED[2d3c61df8b436a826fb1718d75ba3f9da9111f764a5dd0428b9eedfeb2d7a54945071bc0dc6570e0f2a183aff776db3a]
   DOCKER_PASSWORD: ENCRYPTED[7f03385623a29b5da5853b10e4d0cf615b0eb9ba64a72bb6364bac2af2296620f0fcb2b61834594494a7528e53321cc9]
 
+timeout_in: 2h
+
 windows_docker_builder:
   platform: windows
   os_version: 2019
   info_script: docker info
-  pull_script: docker pull mcr.microsoft.com/windows/servercore:ltsc2019
-  build_core_script: docker build --tag cirrusci/windowsservercore:2019 windowsservercore
-  build_cmake_script: docker build --tag cirrusci/windowsservercore:cmake contrib/cmake
+  pull_script: docker pull mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
+  build_core_script: docker build -m 2GB --tag cirrusci/windowsservercore:2019 windowsservercore
+  build_cmake_script: docker build -m 2GB --tag cirrusci/windowsservercore:cmake contrib/cmake
   push_script: push_docker.bat

--- a/contrib/cmake/Dockerfile
+++ b/contrib/cmake/Dockerfile
@@ -12,3 +12,5 @@ RUN powershell -NoLogo -NoProfile -Command \
 
 RUN powershell -NoLogo -NoProfile -Command \
     choco install -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System' mingw cmake
+    Remove-Item C:\ProgramData\chocolatey\logs\*.* -Force -Recurse ; \
+    Remove-Item C:\Users\ContainerAdministrator\AppData\Local\Temp\*.* -Force -Recurse

--- a/contrib/cmake/Dockerfile
+++ b/contrib/cmake/Dockerfile
@@ -1,16 +1,15 @@
+# !IMPORTANT!
+# * Pass -m 2GB (or more) when building the image.
+# * Configure Docker to use disks larger than the default 20 GB.
 FROM cirrusci/windowsservercore:2019
 
-# Microsoft .NET Framework 4.8 4.8.0.20190930 is broken and causes the
-# installation of visualstudio2019-workload-vctools to fail. To workaround
-# the issue request Microsoft .NET Framework 4.7.2.20180712 instead, which
-# is already installed and thus speeds up installation as well.
 RUN powershell -NoLogo -NoProfile -Command \
-    choco install -y --no-progress dotnetfx --version 4.7.2.20180712
+    choco feature disable -n=usePackageExitCodes ; \
+    choco install -y --no-progress --version=16.8.2.0 visualstudio2019buildtools ; \
+    choco install -y --no-progress --version=1.0.0 visualstudio2019-workload-vctools --parameters="--includeOptional"
 
 RUN powershell -NoLogo -NoProfile -Command \
-    choco install -y --no-progress visualstudio2019buildtools visualstudio2019-workload-vctools
-
-RUN powershell -NoLogo -NoProfile -Command \
-    choco install -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System' mingw cmake
+    choco install -y --no-progress cmake --install-arguments="ADD_CMAKE_TO_PATH=System" ; \
+    choco install -y --no-progress mingw ; \
     Remove-Item C:\ProgramData\chocolatey\logs\*.* -Force -Recurse ; \
     Remove-Item C:\Users\ContainerAdministrator\AppData\Local\Temp\*.* -Force -Recurse

--- a/windowsservercore/Dockerfile
+++ b/windowsservercore/Dockerfile
@@ -1,11 +1,13 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+# Base image on microsoft/dotnet-framework:4.7.1 or later as adviced by Microsoft.
+# https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container-issues
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
 
 RUN powershell -NoLogo -NoProfile -Command \
     netsh interface ipv4 show interfaces ; \
     netsh interface ipv4 set subinterface 18 mtu=1460 store=persistent ; \
     netsh interface ipv4 show interfaces ; \
     Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) ; \
-    choco install -y --no-progress git --params "/GitAndUnixToolsOnPath" ; \
+    choco install -y --no-progress git --parameters="/GitAndUnixToolsOnPath" ; \
     choco install -y --no-progress 7zip ; \
     Remove-Item C:\ProgramData\chocolatey\logs\*.* -Force -Recurse ; \
     Remove-Item C:\Users\ContainerAdministrator\AppData\Local\Temp\*.* -Force -Recurse

--- a/windowsservercore/Dockerfile
+++ b/windowsservercore/Dockerfile
@@ -7,5 +7,5 @@ RUN powershell -NoLogo -NoProfile -Command \
     Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) ; \
     choco install -y --no-progress git --params "/GitAndUnixToolsOnPath" ; \
     choco install -y --no-progress 7zip ; \
-    Remove-Item C:\ProgramData\chocolatey\logs -Force -Recurse ; \
-    Remove-Item C:\Users\ContainerAdministrator\AppData\Local\Temp -Force -Recurse
+    Remove-Item C:\ProgramData\chocolatey\logs\*.* -Force -Recurse ; \
+    Remove-Item C:\Users\ContainerAdministrator\AppData\Local\Temp\*.* -Force -Recurse


### PR DESCRIPTION
This fixes #16. I noticed the `Microsoft.VisualStudio.Workload.NativeDesktop` had an awful lot in common with `Microsoft.VisualStudio.Workload.VCTools` and did some experimenting. Turns out if `--includeOptional` is passed when installing the `visualstudio2019-workload-vctools` package, everything is available to run:
```
git clone https://github.com/Microsoft/vcpkg.git
cd vcpkg
bootstrap-vcpkg.bat
```
The `visualcpp-build-tools` isn't even required I think.

I also changed the cleanup commands to remove the contents of the temporary directories rather than the actual directories as it caused the Visual Studio installer to bail and it's probably not what was intended in the first place. Apart from that I figured it was probably best to base the images on `mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019`. Microsoft itself warns about not using `microsoft/windowsservercore` for Docker images that'll run Visual Studio [here](https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container-issues?view=vs-2019).

This built and ran just fine on my local test machine, but it's vital that the maximum disk size for the Docker image is increased (used 50GB myself) by adding `"storage-opts": [ "size=5GB" ]` to the configuration of the Docker daemon.

Hopefully this fixes the issues with the Windows image for everyone. A test build is running [here](https://cirrus-ci.com/task/6024805268848640), but like I indicated the `build_cmake` script will fail unless the image can grow large enough.