### PR TITLE
Include VC CLI support tools

### DIFF
--- a/contrib/cmake/Dockerfile
+++ b/contrib/cmake/Dockerfile
@@ -6,7 +6,7 @@ FROM cirrusci/windowsservercore:2019
 RUN powershell -NoLogo -NoProfile -Command \
     choco feature disable -n=usePackageExitCodes ; \
     choco install -y --no-progress --version=16.8.2.0 visualstudio2019buildtools ; \
-    choco install -y --no-progress --version=1.0.0 visualstudio2019-workload-vctools --parameters="--add Microsoft.VisualStudio.Component.VC.140 --add Microsoft.VisualStudio.Component.VC.v141.x86.x64" ; \
+    choco install -y --no-progress --version=1.0.0 visualstudio2019-workload-vctools --parameters="--add Microsoft.VisualStudio.Component.VC.140 --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.CLI.Support" ; \
     Remove-Item C:\ProgramData\chocolatey\logs\*.* -Force -Recurse ; \
     Remove-Item C:\Users\ContainerAdministrator\AppData\Local\Temp\*.* -Force -Recurse
 


### PR DESCRIPTION
Commit 6777ec6 removed installation of most optional VC components. This
adds back support for command line operations (nmake, vcvarsall etc.)