### PR TITLE
Build images only on tags

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,12 +5,13 @@ environment:
 timeout_in: 3h
 
 windows_docker_builder:
+  only_if: $CIRRUS_TAG != ''
   use_compute_credits: true
   platform: windows
   os_version: 2019
   info_script: docker info
   pull_script: docker pull mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
-  build_core_script: docker build -m 2GB --tag cirrusci/windowsservercore:2019 windowsservercore
-  build_visualstudio_script: docker build -m 2GB --tag cirrusci/windowsservercore:visualstudio2019 contrib/visualstudio2019
-  build_cmake_script: docker build -m 2GB --tag cirrusci/windowsservercore:cmake contrib/cmake
+  build_core_script: docker build -m 2GB --tag cirrusci/windowsservercore:2019 --tag cirrusci/windowsservercore:2019-$CIRRUS_TAG windowsservercore
+  build_visualstudio_script: docker build -m 2GB --tag cirrusci/windowsservercore:visualstudio2019 --tag cirrusci/windowsservercore:visualstudio2019-$CIRRUS_TAG contrib/visualstudio2019
+  build_cmake_script: docker build -m 2GB --tag cirrusci/windowsservercore:cmake --tag cirrusci/windowsservercore:cmake-$CIRRUS_TAG contrib/cmake
   push_script: push_docker.bat

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# docker-images-windows
+# Common Windows Docker Images for Cirrus CI
 
-Base WindowsDocker images for Cirrus CI.
+Common [Windows docker images](https://hub.docker.com/r/cirrusci/windowsservercore/tags) for Cirrus CI
+that are pre-cached on the machines. 
 
-Since Cirrus CI builds are executed on Google Cloud Platform we need to comply with GCP's restrictions. For example
-[GCP doesn't support the default MTU][1] of 1500 so we need to change it to the maximum possible 1460.
-
-[1]: https://cloud.google.com/compute/docs/containers/#additional_setup_steps
+Note: Please use a `-<year>.<month>` tag in your Dockerfiles when using with [Dockerfile as a CI environment](https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environment)
+feature. All tags not older than 1 year will be precached on the machines which will increase cache hit rate and startup speed.

--- a/push_docker.bat
+++ b/push_docker.bat
@@ -8,9 +8,7 @@ IF not "%CIRRUS_BRANCH%" == "master" GOTO NOTMASTER
 :YESPATH
 
 docker login --username "%DOCKER_USER_NAME%" --password "%DOCKER_PASSWORD%"
-docker push cirrusci/windowsservercore:2019
-docker push cirrusci/windowsservercore:visualstudio2019
-docker push cirrusci/windowsservercore:cmake
+docker push --all-tags cirrusci/windowsservercore
 
 GOTO END
 :NOTMASTER


### PR DESCRIPTION
With this approach we'll create `<yaer>.<month>` tags once in a while to keep the dependencies up-to-date. Such tags will also help customers to increase cache hit rate by using pinned tags in their own Dockerfiles.

Related to https://github.com/cirruslabs/cirrus-ci-docs/issues/947